### PR TITLE
Don't use AWK in libpng for compatiblity

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
 *.glb filter=lfs diff=lfs merge=lfs -text
 *.vrm filter=lfs diff=lfs merge=lfs -text
-* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.glb filter=lfs diff=lfs merge=lfs -text
 *.vrm filter=lfs diff=lfs merge=lfs -text
+* text eol=lf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,8 @@ if (NOT EMSCRIPTEN)
     set(ZLIBINC "${ZLIB_ROOT}")
     set(ZLIB_INCLUDE_DIR "${ZLIB_ROOT}")
 
+    set(AWK "")
+
     add_subdirectory(submodules/libpng EXCLUDE_FROM_ALL)
     target_include_directories(
         png_static PUBLIC


### PR DESCRIPTION
AWK is not necessary and doesn't work on all OSes and has trouble with Windows line-endings. 